### PR TITLE
Fix #7, #8: Compare user and solution based on expressions

### DIFF
--- a/R/strict_check.R
+++ b/R/strict_check.R
@@ -40,7 +40,7 @@
 #'   argument.
 #'
 #' @export
-#'
+#' @importFrom rlang get_expr
 #' @examples
 #' \dontrun{grading_demo()}
 strict_check <- function(success = NULL,
@@ -58,7 +58,7 @@ strict_check <- function(success = NULL,
     stop("I didn't receive your code. Did you write any?")
 
     # Correct answers are all alike
-  } else if (suppressWarnings(user == solution)) {
+  } else if (suppressWarnings(get_expr(user) == get_expr(solution))) {
     return(success)
 
     # But incorrect answers are each incorrect in their own way


### PR DESCRIPTION
Fixes: #7 
Fixes: #8 

This should fix the stated quosure issue:

```
Base operators are not defined for quosures. 
Do you need to unquote the quosure? 
# Bad: myquosure1 == myquosure2 
# Good: !!myquosure1 == !!myquosure2
```